### PR TITLE
don't ignore unknown class in evaluation

### DIFF
--- a/sciencebeam_gym/trainer/models/pix2pix/evaluate.py
+++ b/sciencebeam_gym/trainer/models/pix2pix/evaluate.py
@@ -79,7 +79,7 @@ def _evaluate_from_confusion_matrix(confusion, accuracy=None):
     macro_f1=macro_f1
   )
 
-def evaluate_predictions(labels, predictions, n_classes, has_unknown_class=False):
+def evaluate_predictions(labels, predictions, n_classes):
   labels = to_1d_vector(labels)
   predictions = to_1d_vector(predictions)
 
@@ -92,16 +92,12 @@ def evaluate_predictions(labels, predictions, n_classes, has_unknown_class=False
     num_classes=n_classes
   )
 
-  if has_unknown_class:
-    # remove unknown class
-    confusion = tf.slice(confusion, [0, 0], [int(n_classes - 1), int(n_classes - 1)])
-
   return _evaluate_from_confusion_matrix(
     confusion=confusion,
     accuracy=accuracy
   )
 
-def evaluate_separate_channels(targets, outputs, has_unknown_class=False):
+def evaluate_separate_channels(targets, outputs):
   n_classes = targets.shape[-1]
 
   labels = output_probabilities_to_class(targets)
@@ -109,8 +105,7 @@ def evaluate_separate_channels(targets, outputs, has_unknown_class=False):
   return evaluate_predictions(
     labels=labels,
     predictions=predictions,
-    n_classes=n_classes,
-    has_unknown_class=has_unknown_class
+    n_classes=n_classes
   )
 
 

--- a/sciencebeam_gym/trainer/models/pix2pix/pix2pix_model.py
+++ b/sciencebeam_gym/trainer/models/pix2pix/pix2pix_model.py
@@ -456,14 +456,13 @@ class Model(object):
 
     if self.use_separate_channels:
       with tf.name_scope("evaluation"):
-        tensors.output_layer_labels = tf.constant(self.dimension_labels)
+        tensors.output_layer_labels = tf.constant(self.dimension_labels_with_unknown)
         evaluation_result = evaluate_separate_channels(
           targets=pix2pix_model.targets,
-          outputs=pix2pix_model.outputs,
-          has_unknown_class=self.use_unknown_class
+          outputs=pix2pix_model.outputs
         )
         tensors.evaluation_result = evaluation_result
-        evaluation_summary(evaluation_result, self.dimension_labels)
+        evaluation_summary(evaluation_result, self.dimension_labels_with_unknown)
     else:
       with tf.name_scope('evaluation'):
         if self.dimension_colors:
@@ -483,8 +482,7 @@ class Model(object):
           evaluation_result = evaluate_predictions(
             labels=tensors.targets_class_indices,
             predictions=tensors.outputs_class_indices,
-            n_classes=len(self.dimension_colors_with_unknown),
-            has_unknown_class=self.use_unknown_class
+            n_classes=len(self.dimension_colors_with_unknown)
           )
           tensors.evaluation_result = evaluation_result
           evaluation_summary(evaluation_result, self.dimension_labels)


### PR DESCRIPTION
The optional 'unknown' is by default added when using separate channels to indicate that it is none of the other classes (to not make the model choose between the classes). Previously the 'unknown' class was ignored in the evaluation but that leads to results being reported higher (ignoring when the model should have not chosen one of the classes). That has been changed now and the 'unknown' class is reported as a class on it's own (if enabled).