### PR TITLE
use cv and crf tag scope by default

### DIFF
--- a/sciencebeam_gym/inference_model/annotate_using_predictions_test.py
+++ b/sciencebeam_gym/inference_model/annotate_using_predictions_test.py
@@ -15,7 +15,8 @@ from sciencebeam_gym.utils.bounding_box import (
 from sciencebeam_gym.inference_model.annotate_using_predictions import (
   AnnotatedImage,
   annotate_structured_document_using_predicted_images,
-  parse_args
+  parse_args,
+  CV_TAG_SCOPE
 )
 
 TAG_1 = 'tag1'
@@ -85,7 +86,7 @@ class TestAnnotateStructuredDocumentUsingPredictedImages(object):
       structured_document,
       [filled_image(BG_COLOR, {TAG_1: COLOR_1})]
     )
-    assert structured_document.get_tag(token_1) is None
+    assert structured_document.get_tag(token_1, scope=CV_TAG_SCOPE) is None
 
   def test_should_tag_single_token_within_prediction(self):
     token_1 = SimpleToken(TOKEN_TEXT_1)
@@ -99,7 +100,7 @@ class TestAnnotateStructuredDocumentUsingPredictedImages(object):
       structured_document,
       [filled_image(COLOR_1, {TAG_1: COLOR_1})]
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CV_TAG_SCOPE) == TAG_1
 
   def test_should_tag_single_token_within_full_prediction_at_smaller_scale(self):
     token_1 = SimpleToken(TOKEN_TEXT_1)
@@ -116,7 +117,7 @@ class TestAnnotateStructuredDocumentUsingPredictedImages(object):
       structured_document,
       [filled_image(COLOR_1, {TAG_1: COLOR_1}, width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT)]
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CV_TAG_SCOPE) == TAG_1
 
   def test_should_tag_single_token_within_partial_prediction_at_same_scale(self):
     token_1 = SimpleToken(TOKEN_TEXT_1)
@@ -147,7 +148,7 @@ class TestAnnotateStructuredDocumentUsingPredictedImages(object):
       structured_document,
       [annotated_image]
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CV_TAG_SCOPE) == TAG_1
 
   def test_should_tag_single_token_within_partial_prediction_at_smaller_scale(self):
     token_1 = SimpleToken(TOKEN_TEXT_1)
@@ -174,7 +175,7 @@ class TestAnnotateStructuredDocumentUsingPredictedImages(object):
       structured_document,
       [annotated_image]
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CV_TAG_SCOPE) == TAG_1
 
 class TestParseArgs(object):
   def test_should_raise_error_if_not_enough_arguments_are_passed(self):

--- a/sciencebeam_gym/inference_model/extract_from_annotated_document.py
+++ b/sciencebeam_gym/inference_model/extract_from_annotated_document.py
@@ -14,11 +14,11 @@ def get_lines(structured_document):
     for line in structured_document.get_lines_of_page(page):
       yield line
 
-def extract_from_annotated_tokens(structured_document, tokens):
+def extract_from_annotated_tokens(structured_document, tokens, tag_scope=None):
   previous_tokens = []
   previous_tag = None
   for token in tokens:
-    tag = structured_document.get_tag(token)
+    tag = structured_document.get_tag(token, scope=tag_scope)
     if not previous_tokens:
       previous_tokens = [token]
       previous_tag = tag
@@ -37,11 +37,11 @@ def extract_from_annotated_tokens(structured_document, tokens):
       ' '.join(structured_document.get_text(t) for t in previous_tokens)
     )
 
-def extract_from_annotated_lines(structured_document, lines):
+def extract_from_annotated_lines(structured_document, lines, tag_scope=None):
   previous_item = None
   for line in lines:
     tokens = structured_document.get_tokens_of_line(line)
-    for item in extract_from_annotated_tokens(structured_document, tokens):
+    for item in extract_from_annotated_tokens(structured_document, tokens, tag_scope=tag_scope):
       if previous_item is not None:
         if previous_item.tag == item.tag:
           previous_item = previous_item.extend(item)
@@ -53,6 +53,7 @@ def extract_from_annotated_lines(structured_document, lines):
   if previous_item is not None:
     yield previous_item
 
-def extract_from_annotated_document(structured_document):
-  for x in extract_from_annotated_lines(structured_document, get_lines(structured_document)):
-    yield x
+def extract_from_annotated_document(structured_document, tag_scope=None):
+  return extract_from_annotated_lines(
+    structured_document, get_lines(structured_document), tag_scope=tag_scope
+  )

--- a/sciencebeam_gym/inference_model/extract_from_annotated_document_test.py
+++ b/sciencebeam_gym/inference_model/extract_from_annotated_document_test.py
@@ -17,6 +17,8 @@ TAG_1 = 'tag1'
 TAG_2 = 'tag2'
 TAG_3 = 'tag3'
 
+TAG_SCOPE_1 = 'tag_scope1'
+
 def get_logger():
   return logging.getLogger(__name__)
 
@@ -58,6 +60,16 @@ class TestExtractFromAnnotatedDocument(object):
       (x.tag, x.text)
       for x in
       extract_from_annotated_document(structured_document)
+    ]
+    assert result == [(TAG_1, TEXT_1)]
+
+  def test_should_extract_from_different_tag_scope(self):
+    lines = [SimpleLine([SimpleToken(TEXT_1, tag=TAG_1, tag_scope=TAG_SCOPE_1)])]
+    structured_document = SimpleStructuredDocument(lines=lines)
+    result = [
+      (x.tag, x.text)
+      for x in
+      extract_from_annotated_document(structured_document, tag_scope=TAG_SCOPE_1)
     ]
     assert result == [(TAG_1, TEXT_1)]
 

--- a/sciencebeam_gym/models/text/crf/annotate_using_predictions.py
+++ b/sciencebeam_gym/models/text/crf/annotate_using_predictions.py
@@ -3,8 +3,6 @@ import logging
 import pickle
 from itertools import repeat
 
-from lxml import etree
-
 from sciencebeam_gym.utils.tf import (
   FileIO
 )
@@ -18,6 +16,10 @@ from sciencebeam_gym.models.text.feature_extractor import (
 
 from sciencebeam_gym.structured_document.structured_document_loader import (
   load_lxml_structured_document
+)
+
+from sciencebeam_gym.structured_document.structured_document_saver import (
+  save_structured_document
 )
 
 def get_logger():
@@ -118,8 +120,7 @@ def main(argv=None):
   )
 
   get_logger().info('writing result to: %s', args.output_path)
-  with FileIO(args.output_path, 'w') as out_f:
-    out_f.write(etree.tostring(structured_document.root))
+  save_structured_document(args.output_path, structured_document)
 
 if __name__ == '__main__':
   logging.basicConfig(level='INFO')

--- a/sciencebeam_gym/models/text/crf/annotate_using_predictions_test.py
+++ b/sciencebeam_gym/models/text/crf/annotate_using_predictions_test.py
@@ -21,7 +21,8 @@ from sciencebeam_gym.utils.bounding_box import (
 
 from sciencebeam_gym.models.text.crf.annotate_using_predictions import (
   annotate_structured_document_using_predictions,
-  predict_and_annotate_structured_document
+  predict_and_annotate_structured_document,
+  CRF_TAG_SCOPE
 )
 
 TAG_1 = 'tag1'
@@ -46,7 +47,7 @@ class TestAnnotateStructuredDocumentUsingPredictions(object):
       structured_document,
       [TAG_1]
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CRF_TAG_SCOPE) == TAG_1
 
   def test_should_not_tag_using_none_tag(self):
     token_1 = SimpleToken(TOKEN_TEXT_1)
@@ -55,7 +56,7 @@ class TestAnnotateStructuredDocumentUsingPredictions(object):
       structured_document,
       [NONE_TAG]
     )
-    assert structured_document.get_tag(token_1) is None
+    assert structured_document.get_tag(token_1, scope=CRF_TAG_SCOPE) is None
 
   def test_should_tag_single_token_using_prediction_and_check_token_props(self):
     token_1 = SimpleToken(TOKEN_TEXT_1, bounding_box=BOUNDING_BOX)
@@ -69,7 +70,7 @@ class TestAnnotateStructuredDocumentUsingPredictions(object):
       [TAG_1],
       token_props_list
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CRF_TAG_SCOPE) == TAG_1
 
   def test_should_raise_error_if_token_props_do_not_match(self):
     token_1 = SimpleToken(TOKEN_TEXT_1, bounding_box=BOUNDING_BOX)
@@ -101,5 +102,5 @@ class TestPredictAndAnnotateStructuredDocument(object):
       structured_document,
       model
     )
-    assert structured_document.get_tag(token_1) == TAG_1
+    assert structured_document.get_tag(token_1, scope=CRF_TAG_SCOPE) == TAG_1
     model.predict.assert_called_with(X)

--- a/sciencebeam_gym/models/text/crf/crfsuite_training_pipeline_test.py
+++ b/sciencebeam_gym/models/text/crf/crfsuite_training_pipeline_test.py
@@ -45,7 +45,8 @@ TAG_2 = 'tag2'
 DEFAULT_ARGS = dict(
   source_file_column='url',
   cv_source_file_list=None,
-  cv_source_file_column='url'
+  cv_source_file_column='url',
+  cv_source_tag_scope=CV_TAG_SCOPE
 )
 
 class TestLoadAndConvertToTokenProps(object):
@@ -55,7 +56,10 @@ class TestLoadAndConvertToTokenProps(object):
       with patch.object(m, 'structured_document_to_token_props') as \
       structured_document_to_token_props_mock:
 
-        load_and_convert_to_token_props(FILE_1, None, page_range=PAGE_RANGE)
+        load_and_convert_to_token_props(
+          FILE_1, None, cv_source_tag_scope=CV_TAG_SCOPE,
+          page_range=PAGE_RANGE
+        )
         load_structured_document_mock.assert_called_with(
           FILE_1, page_range=PAGE_RANGE
         )
@@ -69,7 +73,10 @@ class TestLoadAndConvertToTokenProps(object):
       with patch.object(m, 'structured_document_to_token_props') as \
       structured_document_to_token_props_mock:
 
-        load_and_convert_to_token_props(FILE_1, FILE_2, page_range=PAGE_RANGE)
+        load_and_convert_to_token_props(
+          FILE_1, FILE_2, cv_source_tag_scope=CV_TAG_SCOPE,
+          page_range=PAGE_RANGE
+        )
         load_structured_document_mock.assert_any_call(
           FILE_1, page_range=PAGE_RANGE
         )
@@ -82,7 +89,7 @@ class TestLoadAndConvertToTokenProps(object):
       SimpleToken(TEXT_1, tag=TAG_1)
     ])])
     cv_structured_document = SimpleStructuredDocument(lines=[SimpleLine([
-      SimpleToken(TEXT_1, tag=TAG_2)
+      SimpleToken(TEXT_1, tag=TAG_2, tag_scope=CV_TAG_SCOPE)
     ])])
     m = crfsuite_training_pipeline
     with patch.object(m, 'load_structured_document') as load_structured_document_mock:
@@ -93,7 +100,10 @@ class TestLoadAndConvertToTokenProps(object):
           structured_document,
           cv_structured_document
         ]
-        load_and_convert_to_token_props(FILE_1, FILE_2, page_range=PAGE_RANGE)
+        load_and_convert_to_token_props(
+          FILE_1, FILE_2, cv_source_tag_scope=CV_TAG_SCOPE,
+          page_range=PAGE_RANGE
+        )
         load_structured_document_mock.assert_any_call(
           FILE_1, page_range=PAGE_RANGE
         )
@@ -110,10 +120,11 @@ class TestLoadTokenPropsListByDocument(object):
       load_and_convert_to_token_props_mock:
 
       result = load_token_props_list_by_document(
-        [FILE_1], None, page_range=PAGE_RANGE, progress=False
+        [FILE_1], None, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE, progress=False
       )
       load_and_convert_to_token_props_mock.assert_called_with(
-        FILE_1, None, page_range=PAGE_RANGE
+        FILE_1, None, cv_source_tag_scope=CV_TAG_SCOPE, page_range=PAGE_RANGE
       )
       assert result == [load_and_convert_to_token_props_mock.return_value]
 
@@ -123,10 +134,12 @@ class TestLoadTokenPropsListByDocument(object):
       load_and_convert_to_token_props_mock:
 
       result = load_token_props_list_by_document(
-        [FILE_1], [FILE_2], page_range=PAGE_RANGE, progress=False
+        [FILE_1], [FILE_2], cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE, progress=False
       )
       load_and_convert_to_token_props_mock.assert_called_with(
-        FILE_1, FILE_2, page_range=PAGE_RANGE
+        FILE_1, FILE_2, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE
       )
       assert result == [load_and_convert_to_token_props_mock.return_value]
 
@@ -138,13 +151,16 @@ class TestLoadTokenPropsListByDocument(object):
       return_values = [Mock(), Mock()]
       load_and_convert_to_token_props_mock.side_effect = return_values
       result = load_token_props_list_by_document(
-        [FILE_1, FILE_2], None, page_range=PAGE_RANGE, progress=False
+        [FILE_1, FILE_2], None, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE, progress=False
       )
       load_and_convert_to_token_props_mock.assert_any_call(
-        FILE_1, None, page_range=PAGE_RANGE
+        FILE_1, None, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE
       )
       load_and_convert_to_token_props_mock.assert_any_call(
-        FILE_2, None, page_range=PAGE_RANGE
+        FILE_2, None, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE
       )
       assert set(result) == set(return_values)
 
@@ -158,7 +174,8 @@ class TestLoadTokenPropsListByDocument(object):
         RuntimeError('oh dear'), valid_response
       ]
       result = load_token_props_list_by_document(
-        [FILE_1, FILE_2], None, page_range=PAGE_RANGE, progress=False
+        [FILE_1, FILE_2], None, cv_source_tag_scope=CV_TAG_SCOPE,
+        page_range=PAGE_RANGE, progress=False
       )
       assert result == [valid_response]
 
@@ -170,9 +187,14 @@ class TestTrainModel(object):
       with patch.object(m, 'CrfSuiteModel') as CrfSuiteModel_mock:
         with patch.object(m, 'pickle') as pickle:
           with patch.object(m, 'token_props_list_to_features') as _:
-            train_model([FILE_1], [FILE_2], page_range=PAGE_RANGE, progress=False)
+            train_model(
+              [FILE_1], [FILE_2],
+              cv_source_tag_scope=CV_TAG_SCOPE,
+              page_range=PAGE_RANGE, progress=False
+            )
             load_token_props_list_by_document_mock.assert_called_with(
-              [FILE_1], [FILE_2], page_range=PAGE_RANGE, progress=False
+              [FILE_1], [FILE_2], cv_source_tag_scope=CV_TAG_SCOPE,
+              page_range=PAGE_RANGE, progress=False
             )
             model = CrfSuiteModel_mock.return_value
             model.fit.assert_called_with(ANY, ANY)
@@ -187,7 +209,11 @@ class TestTrainModel(object):
           with patch.object(m, 'token_props_list_to_features') as _:
             with pytest.raises(AssertionError):
               load_token_props_list_by_document_mock.return_value = []
-              train_model([FILE_1], [FILE_2], page_range=PAGE_RANGE)
+              train_model(
+                [FILE_1], [FILE_2],
+                cv_source_tag_scope=CV_TAG_SCOPE,
+                page_range=PAGE_RANGE
+              )
 
 class TestSaveModel(object):
   def test_should_call_save_content(self):
@@ -216,6 +242,7 @@ class TestRun(object):
           train_model_mock.assert_called_with(
             load_file_list.return_value,
             None,
+            cv_source_tag_scope=opt.cv_source_tag_scope,
             page_range=PAGE_RANGE
           )
           save_model_mock.assert_called_with(
@@ -249,6 +276,7 @@ class TestRun(object):
           train_model_mock.assert_called_with(
             file_list,
             cv_file_list,
+            cv_source_tag_scope=opt.cv_source_tag_scope,
             page_range=PAGE_RANGE
           )
           save_model_mock.assert_called_with(

--- a/sciencebeam_gym/models/text/feature_extractor.py
+++ b/sciencebeam_gym/models/text/feature_extractor.py
@@ -1,11 +1,14 @@
 from functools import partial
 
+from sciencebeam_gym.inference_model.annotate_using_predictions import (
+  CV_TAG_SCOPE
+)
+
 from sciencebeam_gym.structured_document import (
   merge_token_tag
 )
 
 NONE_TAG = 'O'
-CV_TAG_SCOPE = 'cv'
 
 def structured_document_to_token_props(structured_document):
   pages = list(structured_document.get_pages())
@@ -101,11 +104,15 @@ def remove_labels_from_token_props_list(token_props_list):
 def token_props_list_to_labels(token_props_list):
   return [token_props.get('tag') or NONE_TAG for token_props in token_props_list]
 
-def merge_with_cv_structured_document(structured_document, cv_structured_document):
+def merge_with_cv_structured_document(
+  structured_document, cv_structured_document,
+  cv_source_tag_scope=CV_TAG_SCOPE):
+
   structured_document.merge_with(
     cv_structured_document,
     partial(
       merge_token_tag,
+      source_scope=cv_source_tag_scope,
       target_scope=CV_TAG_SCOPE
     )
   )

--- a/sciencebeam_gym/preprocess/preprocessing_utils.py
+++ b/sciencebeam_gym/preprocess/preprocessing_utils.py
@@ -25,6 +25,10 @@ from sciencebeam_gym.utils.collection import (
   sort_and_groupby_to_dict
 )
 
+from sciencebeam_gym.utils.pages_zip import (
+  save_pages
+)
+
 from sciencebeam_gym.beam_utils.io import (
   dirname,
   find_matching_filenames,
@@ -255,16 +259,6 @@ def get_output_file(filename, source_base_path, output_base_path, output_file_su
       None, output_file_suffix
     )
   )
-
-def save_pages(output_filename, ext, bytes_by_page):
-  mkdirs_if_not_exists(dirname(output_filename))
-  with FileSystems.create(output_filename) as f:
-    with ZipFile(f, 'w', compression=ZIP_DEFLATED) as zf:
-      for i, data in enumerate(bytes_by_page):
-        page_filename = 'page-%s%s' % (1 + i, ext)
-        get_logger().debug('page_filename: %s', page_filename)
-        zf.writestr(page_filename, data)
-    return output_filename
 
 def save_svg_roots(output_filename, svg_pages):
   return save_pages(output_filename, '.svg', (

--- a/sciencebeam_gym/structured_document/structured_document_loader.py
+++ b/sciencebeam_gym/structured_document/structured_document_loader.py
@@ -7,6 +7,10 @@ from lxml.builder import E
 
 from apache_beam.io.filesystems import FileSystems
 
+from sciencebeam_gym.utils.pages_zip import (
+  load_pages
+)
+
 from sciencebeam_gym.structured_document.lxml import (
   LxmlStructuredDocument
 )
@@ -39,19 +43,10 @@ def load_lxml_structured_document(filename, page_range=None):
     return structured_document
 
 def load_svg_pages_structured_document(filename, page_range=None):
-  with FileSystems.open(filename) as f:
-    with ZipFile(f) as zf:
-      filenames = zf.namelist()
-      if page_range:
-        filenames = filenames[
-          max(0, page_range[0] - 1):
-          page_range[1]
-        ]
-      svg_roots = []
-      for filename in filenames:
-        with zf.open(filename) as svg_f:
-          svg_roots.append(etree.parse(svg_f).getroot())
-    return SvgStructuredDocument(svg_roots)
+  return SvgStructuredDocument([
+    etree.parse(svg_f).getroot()
+    for svg_f in load_pages(filename, page_range=page_range)
+  ])
 
 def load_structured_document(filename, page_range=None):
   structured_document_type = get_structuctured_document_type(filename)

--- a/sciencebeam_gym/structured_document/structured_document_saver.py
+++ b/sciencebeam_gym/structured_document/structured_document_saver.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from lxml import etree
+
+from sciencebeam_gym.beam_utils.io import (
+  save_file_content
+)
+
+from sciencebeam_gym.utils.pages_zip import (
+  save_pages
+)
+
+from sciencebeam_gym.structured_document.lxml import (
+  LxmlStructuredDocument
+)
+
+from sciencebeam_gym.structured_document.svg import (
+  SvgStructuredDocument
+)
+
+def save_lxml_structured_document(filename, lxml_structured_document):
+  save_file_content(filename, etree.tostring(lxml_structured_document.root))
+
+def save_svg_structured_document(filename, svg_structured_document):
+  return save_pages(filename, '.svg', (
+    etree.tostring(svg_page)
+    for svg_page in svg_structured_document.get_pages()
+  ))
+
+def save_structured_document(filename, structured_document):
+  if isinstance(structured_document, LxmlStructuredDocument):
+    return save_lxml_structured_document(filename, structured_document)
+  if isinstance(structured_document, SvgStructuredDocument):
+    return save_svg_structured_document(filename, structured_document)
+  raise RuntimeError('unsupported type: %s' % type(structured_document))

--- a/sciencebeam_gym/structured_document/structured_document_saver_test.py
+++ b/sciencebeam_gym/structured_document/structured_document_saver_test.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from mock import patch, ANY
+
+from lxml.builder import E
+
+from sciencebeam_gym.structured_document.lxml import (
+  LxmlStructuredDocument
+)
+
+from sciencebeam_gym.structured_document.svg import (
+  SvgStructuredDocument
+)
+
+import sciencebeam_gym.structured_document.structured_document_saver as structured_document_saver
+from sciencebeam_gym.structured_document.structured_document_saver import (
+  save_lxml_structured_document,
+  save_svg_structured_document,
+  save_structured_document
+)
+
+FILE_1 = 'file1'
+
+class TestSaveLxmlStructuredDocument(object):
+  def test_should_call_save_file_content(self):
+    m = structured_document_saver
+    root = E.DOCUMENT()
+    with patch.object(m, 'save_file_content') as save_file_content:
+      with patch.object(m, 'etree') as etree:
+        save_lxml_structured_document(FILE_1, LxmlStructuredDocument(root))
+        save_file_content.assert_called_with(FILE_1, etree.tostring(root))
+
+class TestSaveSvgStructuredDocument(object):
+  def test_should_call_save_pages(self):
+    m = structured_document_saver
+    root = E.svg()
+    with patch.object(m, 'save_pages') as save_pages:
+      with patch.object(m, 'etree') as etree:
+        save_svg_structured_document(FILE_1, SvgStructuredDocument(root))
+        save_pages.assert_called_with(FILE_1, '.svg', ANY)
+        args, _ = save_pages.call_args
+        assert list(args[2]) == [etree.tostring(root)]
+
+class TestSaveStructuredDocument(object):
+  def test_should_call_save_lxml_structured_document(self):
+    structured_document = LxmlStructuredDocument(E.DOCUMENT)
+    m = structured_document_saver
+    with patch.object(m, 'save_lxml_structured_document') as save_lxml_structured_document_mock:
+      save_structured_document(FILE_1, structured_document)
+      save_lxml_structured_document_mock.assert_called_with(FILE_1, structured_document)
+
+  def test_should_call_save_svg_structured_document(self):
+    structured_document = SvgStructuredDocument(E.svg)
+    m = structured_document_saver
+    with patch.object(m, 'save_svg_structured_document') as save_svg_structured_document_mock:
+      save_structured_document(FILE_1, structured_document)
+      save_svg_structured_document_mock.assert_called_with(FILE_1, structured_document)

--- a/sciencebeam_gym/utils/pages_zip.py
+++ b/sciencebeam_gym/utils/pages_zip.py
@@ -1,0 +1,35 @@
+import logging
+from zipfile import ZipFile, ZIP_DEFLATED
+
+from apache_beam.io.filesystems import FileSystems
+
+from sciencebeam_gym.beam_utils.io import (
+  dirname,
+  mkdirs_if_not_exists
+)
+
+def get_logger():
+  return logging.getLogger(__name__)
+
+def load_pages(filename, page_range=None):
+  with FileSystems.open(filename) as f:
+    with ZipFile(f) as zf:
+      filenames = zf.namelist()
+      if page_range:
+        filenames = filenames[
+          max(0, page_range[0] - 1):
+          page_range[1]
+        ]
+      for filename in filenames:
+        with zf.open(filename) as f:
+          yield f
+
+def save_pages(output_filename, ext, bytes_by_page):
+  mkdirs_if_not_exists(dirname(output_filename))
+  with FileSystems.create(output_filename) as f:
+    with ZipFile(f, 'w', compression=ZIP_DEFLATED) as zf:
+      for i, data in enumerate(bytes_by_page):
+        page_filename = 'page-%s%s' % (1 + i, ext)
+        get_logger().debug('page_filename: %s', page_filename)
+        zf.writestr(page_filename, data)
+    return output_filename


### PR DESCRIPTION
One advantage of using separate tag scopes by default is that they don't have to change (when combining them) and it is more clear where the tag comes from (e.g. cv or crf prediction)

(also re-used some of the newly created utility methods for loading and saving structured documents)