### PR TITLE
Trigger downstream updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,13 @@ elifeLibrary {
         elifeLocalTests './project_tests.sh'
     }
 
-    stage 'Merge to master', {
-        elifeGitMoveToBranch commit, 'master'
-    }
+    elifeMainlineOnly {
+        stage 'Merge to master', {
+            elifeGitMoveToBranch commit, 'master'
+        }
 
-    stage 'Downstream', {
-        build job: 'dependencies-sciencebeam-update-sciencebeam-gym', wait: false, parameters: [string(name: 'commit', value: commit)]
+        stage 'Downstream', {
+            build job: 'dependencies-sciencebeam-update-sciencebeam-gym', wait: false, parameters: [string(name: 'commit', value: commit)]
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 elifeLibrary {
+    def commit
     stage 'Checkout', {
         checkout scm
+        commit = elifeGitRevision()
     }
 
     stage 'Build image', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,4 +10,12 @@ elifeLibrary {
     stage 'Run tests', {
         elifeLocalTests './project_tests.sh'
     }
+
+    stage 'Merge to master', {
+        elifeGitMoveToBranch commit, 'master'
+    }
+
+    stage 'Downstream', {
+        build job: 'dependencies-sciencebeam-update-sciencebeam-gym', wait: false, parameters: [string(name: 'commit', value: commit)]
+    }
 }


### PR DESCRIPTION
We merge to `master` (a new branch) whenever tests are passing, and then trigger https://alfred.elifesciences.org/job/dependencies/job/dependencies-sciencebeam-update-sciencebeam-gym/