### PR TITLE
make source file list relative to source base path if it is not an absolute path

### DIFF
--- a/sciencebeam_gym/preprocess/get_output_files.py
+++ b/sciencebeam_gym/preprocess/get_output_files.py
@@ -8,7 +8,8 @@ from sciencebeam_gym.utils.file_list import (
 
 from sciencebeam_gym.preprocess.preprocessing_utils import (
   get_or_validate_base_path,
-  get_output_file
+  get_output_file,
+  join_if_relative_path
 )
 
 from sciencebeam_gym.preprocess.check_file_list import (
@@ -85,7 +86,10 @@ def get_output_file_list(file_list, source_base_path, output_base_path, output_f
 
 def run(opt):
   source_file_list = load_file_list(
-    opt.source_file_list,
+    join_if_relative_path(
+      opt.source_base_path,
+      opt.source_file_list
+    ),
     column=opt.source_file_column,
     limit=opt.limit
   )

--- a/sciencebeam_gym/preprocess/preprocessing_utils.py
+++ b/sciencebeam_gym/preprocess/preprocessing_utils.py
@@ -222,7 +222,11 @@ def is_relative_path(path):
   return not path.startswith('/') and '://' not in path
 
 def join_if_relative_path(base_path, path):
-  return FileSystems.join(base_path, path) if is_relative_path(path) else path
+  return (
+    FileSystems.join(base_path, path)
+    if base_path and is_relative_path(path)
+    else path
+  )
 
 def change_ext(path, old_ext, new_ext):
   if old_ext is None:

--- a/sciencebeam_gym/preprocess/preprocessing_utils_test.py
+++ b/sciencebeam_gym/preprocess/preprocessing_utils_test.py
@@ -12,11 +12,12 @@ from sciencebeam_gym.preprocess.preprocessing_utils import (
   svg_page_to_blockified_png_bytes,
   group_file_pairs_by_parent_directory_or_name,
   convert_pdf_bytes_to_lxml,
+  join_if_relative_path,
   change_ext,
   base_path_for_file_list,
   get_or_validate_base_path,
   get_output_file,
-  parse_page_range
+  parse_page_range,
 )
 
 PROCESSING_UTILS = 'sciencebeam_gym.preprocess.preprocessing_utils'
@@ -114,6 +115,16 @@ class TestConvertPdfBytesToLxml(object):
         DEFAULT_PDF_TO_LXML_ARGS + ['-f', '1', '-l', '3']
       )
       assert lxml_content == LXML_CONTENT_1
+
+class TestJoinIfRelativePath(object):
+  def test_should_return_path_if_base_path_is_none(self):
+    assert join_if_relative_path(None, 'file') == 'file'
+
+  def test_should_return_path_if_not_relative(self):
+    assert join_if_relative_path('/parent', '/other/file') == '/other/file'
+
+  def test_should_return_joined_path_if_relative(self):
+    assert join_if_relative_path('/parent', 'file') == '/parent/file'
 
 class TestChangeExt(object):
   def test_should_replace_simple_ext_with_simple_ext(self):


### PR DESCRIPTION
this is to reduce typing. If `--source-file-list` is a relative path and `--source-data-path` is provided, then _source file list_ is assumed to be relative to _source data path_.

(another small enhancement that I neglected to commit before)