### PR TITLE
make matching annotator configurable

### DIFF
--- a/sciencebeam_gym/preprocess/annotation/matching_annotator.py
+++ b/sciencebeam_gym/preprocess/annotation/matching_annotator.py
@@ -214,20 +214,26 @@ def get_fuzzy_match_filter(
     return check
 
 
+DEFAULT_SEQ_MIN_MATCH_COUNT = 5
+DEFAULT_CHOICE_MIN_MATCH_COUNT = 1
+
+DEFAULT_SEQ_RATIO_MIN_MATCH_COUNT = 50
+DEFAULT_CHOICE_RATIO_MIN_MATCH_COUNT = 100
+
 DEFAULT_SEQ_FUZZY_MATCH_FILTER = get_fuzzy_match_filter(
     DEFAULT_SCORE_THRESHOLD,
-    5,
-    0.9,
-    50,
-    0.9
+    min_match_count=DEFAULT_SEQ_MIN_MATCH_COUNT,
+    total_match_threshold=DEFAULT_SCORE_THRESHOLD,
+    ratio_min_match_count=DEFAULT_SEQ_RATIO_MIN_MATCH_COUNT,
+    ratio_threshold=DEFAULT_SCORE_THRESHOLD
 )
 
 DEFAULT_CHOICE_FUZZY_MATCH_FILTER = get_fuzzy_match_filter(
     DEFAULT_SCORE_THRESHOLD,
-    1,
-    0.9,
-    100,
-    0.9
+    min_match_count=DEFAULT_CHOICE_MIN_MATCH_COUNT,
+    total_match_threshold=DEFAULT_SCORE_THRESHOLD,
+    ratio_min_match_count=DEFAULT_CHOICE_RATIO_MIN_MATCH_COUNT,
+    ratio_threshold=DEFAULT_SCORE_THRESHOLD
 )
 
 
@@ -632,6 +638,8 @@ class MatchingAnnotator(AbstractAnnotator):
         self.target_annotations = target_annotations
         if matching_annotator_config is None:
             matching_annotator_config = MatchingAnnotatorConfig(**kwargs)
+        elif kwargs:
+            raise ValueError('either matching_annotator_config or kwargs expected')
         self.matching_annotator_config = matching_annotator_config
 
     def annotate(self, structured_document):

--- a/sciencebeam_gym/preprocess/annotation/matching_annotator.py
+++ b/sciencebeam_gym/preprocess/annotation/matching_annotator.py
@@ -214,26 +214,33 @@ def get_fuzzy_match_filter(
     return check
 
 
+def get_simple_fuzzy_match_filter(
+        score_threshold, min_match_count=1, ratio_min_match_count=100):
+    return get_fuzzy_match_filter(
+        score_threshold,
+        min_match_count=min_match_count,
+        total_match_threshold=score_threshold,
+        ratio_min_match_count=ratio_min_match_count,
+        ratio_threshold=score_threshold
+    )
+
+
 DEFAULT_SEQ_MIN_MATCH_COUNT = 5
 DEFAULT_CHOICE_MIN_MATCH_COUNT = 1
 
 DEFAULT_SEQ_RATIO_MIN_MATCH_COUNT = 50
 DEFAULT_CHOICE_RATIO_MIN_MATCH_COUNT = 100
 
-DEFAULT_SEQ_FUZZY_MATCH_FILTER = get_fuzzy_match_filter(
+DEFAULT_SEQ_FUZZY_MATCH_FILTER = get_simple_fuzzy_match_filter(
     DEFAULT_SCORE_THRESHOLD,
     min_match_count=DEFAULT_SEQ_MIN_MATCH_COUNT,
-    total_match_threshold=DEFAULT_SCORE_THRESHOLD,
-    ratio_min_match_count=DEFAULT_SEQ_RATIO_MIN_MATCH_COUNT,
-    ratio_threshold=DEFAULT_SCORE_THRESHOLD
+    ratio_min_match_count=DEFAULT_SEQ_RATIO_MIN_MATCH_COUNT
 )
 
-DEFAULT_CHOICE_FUZZY_MATCH_FILTER = get_fuzzy_match_filter(
+DEFAULT_CHOICE_FUZZY_MATCH_FILTER = get_simple_fuzzy_match_filter(
     DEFAULT_SCORE_THRESHOLD,
     min_match_count=DEFAULT_CHOICE_MIN_MATCH_COUNT,
-    total_match_threshold=DEFAULT_SCORE_THRESHOLD,
-    ratio_min_match_count=DEFAULT_CHOICE_RATIO_MIN_MATCH_COUNT,
-    ratio_threshold=DEFAULT_SCORE_THRESHOLD
+    ratio_min_match_count=DEFAULT_CHOICE_RATIO_MIN_MATCH_COUNT
 )
 
 


### PR DESCRIPTION
A `MatchingAnnotatorConfig` can now be passed in to `MatchingAnnotator`, encapsulating all of the global config. Including the fuzzy match filters with their threshold.