### PR TITLE
Revert "Bump tensorflow-transform from 0.25.0 to 0.30.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ sciencebeam-alignment==0.0.5
 sciencebeam-utils==0.1.4
 sklearn-crfsuite==0.3.6
 six==1.16.0
-tensorflow-transform==0.30.0
+tensorflow-transform==0.25.0
 tqdm==4.60.0


### PR DESCRIPTION
Reverts elifesciences/sciencebeam-gym#334

This also caused a TensorFlow 2 upgrade, which wasn't intended.