### PR TITLE
improve bounding box accuracy, use second pass

### DIFF
--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes.py
@@ -268,6 +268,7 @@ def run(
         logger=LOGGER,
         desc='processing images:'
     ):
+        LOGGER.debug('processing article image: %r', image_descriptor.href)
         template_image = PIL.Image.open(BytesIO(read_bytes_with_optional_gz_extension(
             image_descriptor.path
         )))
@@ -351,7 +352,8 @@ def run(
 def main(argv: Optional[List[str]] = None):
     args = parse_args(argv)
     if args.debug:
-        logging.getLogger('sciencebeam_gym').setLevel(logging.DEBUG)
+        for name in ['__main__', 'sciencebeam_gym']:
+            logging.getLogger(name).setLevel(logging.DEBUG)
     LOGGER.info('args: %s', args)
     run(
         pdf_path=args.pdf_file,

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -154,9 +154,12 @@ def _get_resized_opencv_image(
 def _get_detect_and_computed_keypoints(
     image_array: np.ndarray,
     detector: cv.Feature2D,
-    image_cache: dict
+    image_cache: dict,
+    image_id: Optional[str] = None
 ) -> Tuple[Any, Any]:
-    key = f'features-{id(image_array)}'
+    if not image_id:
+        image_id = str(id(image_array))
+    key = f'features-{image_id}'
     result = image_cache.get(key)
     if result is None:
         result = detector.detectAndCompute(image_array, None)
@@ -255,12 +258,14 @@ def get_object_match(
     kp_query, des_query = _get_detect_and_computed_keypoints(
         opencv_query_image,
         detector=detector,
-        image_cache=image_cache
+        image_cache=image_cache,
+        image_id=template_image_id
     )
     kp_train, des_train = _get_detect_and_computed_keypoints(
         opencv_train_image,
         detector=detector,
-        image_cache=image_cache
+        image_cache=image_cache,
+        image_id=target_image_id
     )
     if des_train is None:
         LOGGER.debug('no keypoints found in target image (train)')

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -182,6 +182,8 @@ def get_bounding_box_match_score(
     image_cache: dict,
     target_image_id: str,
     template_image_id: str,
+    similarity_width: int = 512,  # use fixed similarity size for more consistent score
+    similarity_height: int = 512
 ) -> float:
     opencv_target_image = _get_resized_opencv_image(
         target_image,
@@ -220,14 +222,12 @@ def get_bounding_box_match_score(
     LOGGER.debug('cropped_target_image.shape: %s', cropped_target_image.shape)
     resized_template_image = resize_image(
         opencv_template_image,
-        width=cropped_target_image.shape[1],
-        height=cropped_target_image.shape[0]
+        width=similarity_width,
+        height=similarity_height
     )
     score = skimage.metrics.structural_similarity(
-        cropped_target_image,
-        resized_template_image,
-        gaussian_weights=True,
-        win_size=5
+        resize_image(cropped_target_image, similarity_width, similarity_height),
+        resize_image(resized_template_image, similarity_width, similarity_height)
     )
     LOGGER.debug('score: %s', score)
     return score

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -133,10 +133,8 @@ def _get_resized_opencv_image(
     max_width: int,
     max_height: int,
     use_grayscale: bool,
-    image_id: Optional[str] = None
+    image_id: str
 ) -> np.ndarray:
-    if not image_id:
-        image_id = str(id(image))
     key = f'image-{image_id}-{max_width}-{max_height}-{use_grayscale}'
     opencv_image = image_cache.get(key)
     if opencv_image is None:
@@ -155,10 +153,8 @@ def _get_detect_and_computed_keypoints(
     image_array: np.ndarray,
     detector: cv.Feature2D,
     image_cache: dict,
-    image_id: Optional[str] = None
+    image_id: str
 ) -> Tuple[Any, Any]:
-    if not image_id:
-        image_id = str(id(image_array))
     key = f'features-{image_id}'
     result = image_cache.get(key)
     if result is None:
@@ -172,8 +168,8 @@ def get_bounding_box_match_score(
     target_image: PIL.Image.Image,
     template_image: PIL.Image.Image,
     image_cache: dict,
-    target_image_id: Optional[str] = None,
-    template_image_id: Optional[str] = None,
+    target_image_id: str,
+    template_image_id: str,
 ) -> float:
     opencv_target_image = _get_resized_opencv_image(
         target_image,
@@ -235,6 +231,10 @@ def get_object_match(
 ) -> ImageObjectMatchResult:
     if image_cache is None:
         image_cache = {}
+    if not target_image_id:
+        target_image_id = str(id(target_image))
+    if not template_image_id:
+        template_image_id = str(id(template_image))
     detector = object_detector_matcher.detector
     matcher = object_detector_matcher.matcher
     opencv_query_image = _get_resized_opencv_image(

--- a/tests/utils/image_object_matching_test.py
+++ b/tests/utils/image_object_matching_test.py
@@ -132,17 +132,19 @@ class TestGetObjectMatch:
             target_image_array,
             expected_bounding_box,
         )
-        actual_bounding_box = get_object_match(
+        result = get_object_match(
             PIL.Image.fromarray(target_image_array),
             sample_image,
             object_detector_matcher=object_detector_matcher
-        ).target_bounding_box
+        )
+        actual_bounding_box = result.target_bounding_box
         assert actual_bounding_box
         np.testing.assert_allclose(
             actual_bounding_box.to_list(),
             expected_bounding_box.to_list(),
             atol=10
         )
+        assert result.score >= 0.6
 
     @pytest.mark.skip(reason="orb doesn't seem to work well with the sample image")
     def test_should_match_smaller_image_using_orb(


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/188

This now uses a second pass of SIFT feature mapping.
The second pass only looks at the bounding box found by the first pass, therefore getting less distracted by other features on the page.

Additionally calculating similarity score on a fixed size dimension, as the dimension seem to affect the calculated score.