### PR TITLE
improve bounding box accuracy: iteratively improve bounding box (optional)

### DIFF
--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes.py
@@ -18,6 +18,7 @@ from sciencebeam_gym.utils.bounding_box import BoundingBox
 from sciencebeam_gym.utils.collections import get_inverted_dict
 from sciencebeam_gym.utils.io import read_bytes, write_text
 from sciencebeam_gym.utils.image_object_matching import (
+    DEFAULT_MAX_BOUNDING_BOX_ADJUSTMENT_ITERATIONS,
     DEFAULT_MAX_HEIGHT,
     DEFAULT_MAX_WIDTH,
     get_bounding_box_for_image,
@@ -180,6 +181,17 @@ def get_args_parser():
         action='store_true',
         help='Skip errors finding bounding boxes and output missing annotations'
     )
+    parser.add_argument(
+        '--max-bounding-box-adjustment-iterations',
+        type=int,
+        default=DEFAULT_MAX_BOUNDING_BOX_ADJUSTMENT_ITERATIONS,
+        help=(
+            'Maximum bounding box adjustment iterations (0 to disable).'
+            ' Sometimes the bounding box returned by the algorithm is slightly off.'
+            ' With bounding box adjustments, the final bounding box are adjusted'
+            ' in order to maximise the score.'
+        )
+    )
     return parser
 
 
@@ -243,6 +255,7 @@ def run(
     max_internal_height: int,
     use_grayscale: bool,
     skip_errors: bool,
+    max_bounding_box_adjustment_iterations: int,
     output_annotated_images_path: Optional[str] = None
 ):
     pdf_images = get_images_from_pdf(pdf_path)
@@ -281,7 +294,8 @@ def run(
             template_image_id=f'{id(image_descriptor)}-{image_descriptor.href}',
             max_width=max_internal_width,
             max_height=max_internal_height,
-            use_grayscale=use_grayscale
+            use_grayscale=use_grayscale,
+            max_bounding_box_adjustment_iterations=max_bounding_box_adjustment_iterations
         )
         category_id = category_id_by_name.get(image_descriptor.category_name)
         if category_id is None:
@@ -364,7 +378,8 @@ def main(argv: Optional[List[str]] = None):
         max_internal_height=args.max_internal_height,
         use_grayscale=args.use_grayscale,
         skip_errors=args.skip_errors,
-        output_annotated_images_path=args.output_annotated_images_path
+        output_annotated_images_path=args.output_annotated_images_path,
+        max_bounding_box_adjustment_iterations=args.max_bounding_box_adjustment_iterations
     )
 
 

--- a/sciencebeam_gym/utils/bounding_box.py
+++ b/sciencebeam_gym/utils/bounding_box.py
@@ -80,6 +80,17 @@ class BoundingBox(NamedTuple):
     def scale_by(self, rx, ry):
         return BoundingBox(self.x * rx, self.y * ry, self.width * rx, self.height * ry)
 
+    def expand_by(self, dx: float, dy: float) -> 'BoundingBox':
+        return self.shrink_by(-dx, -dy)
+
+    def shrink_by(self, dx: float, dy: float) -> 'BoundingBox':
+        return BoundingBox(
+            self.x + dx,
+            self.y + dy,
+            max(0, self.width - 2 * dx),
+            max(0, self.height - 2 * dy)
+        )
+
     def include(self, other):
         if other.empty():
             return self

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -222,18 +222,18 @@ def get_bounding_box_match_score_summary(
     if bounding_box.width < 10 or bounding_box.height < 10:
         LOGGER.debug('bounding box too small')
         return BoundingBoxScoreSummary(score=0.0, target_bounding_box=target_bounding_box)
-    cropped_target_image = crop_image_to_bounding_box(
-        opencv_target_image, bounding_box
-    )
-    LOGGER.debug('cropped_target_image.shape: %s', cropped_target_image.shape)
     resized_template_image = resize_image(
         opencv_template_image,
         width=similarity_width,
         height=similarity_height
     )
+    cropped_target_image = crop_image_to_bounding_box(
+        opencv_target_image, bounding_box
+    )
+    LOGGER.debug('cropped_target_image.shape: %s', cropped_target_image.shape)
     score = skimage.metrics.structural_similarity(
         resize_image(cropped_target_image, similarity_width, similarity_height),
-        resize_image(resized_template_image, similarity_width, similarity_height)
+        resized_template_image,
     )
     LOGGER.debug('score: %s', score)
     return BoundingBoxScoreSummary(score=score, target_bounding_box=target_bounding_box)

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -73,6 +73,7 @@ class ImageObjectMatchResult(NamedTuple):
     target_points: Optional[np.ndarray]
     keypoint_match_count: int = 0
     score: float = 0
+    target_bounding_box: BoundingBox = EMPTY_BOUNDING_BOX
 
     def __bool__(self) -> bool:
         return self.target_points is not None
@@ -82,7 +83,7 @@ class ImageObjectMatchResult(NamedTuple):
         return (self.score, self.keypoint_match_count)
 
     @property
-    def target_bounding_box(self) -> BoundingBox:
+    def calculated_target_bounding_box(self) -> BoundingBox:
         if self.target_points is None:
             return EMPTY_BOUNDING_BOX
         return get_bounding_box_for_points(
@@ -175,7 +176,12 @@ def _get_detect_and_computed_keypoints(
     return result
 
 
-def get_bounding_box_match_score(
+class BoundingBoxScoreSummary(NamedTuple):
+    score: float
+    target_bounding_box: BoundingBox
+
+
+def get_bounding_box_match_score_summary(
     target_bounding_box: BoundingBox,
     target_image: PIL.Image.Image,
     template_image: PIL.Image.Image,
@@ -184,7 +190,7 @@ def get_bounding_box_match_score(
     template_image_id: str,
     similarity_width: int = 512,  # use fixed similarity size for more consistent score
     similarity_height: int = 512
-) -> float:
+) -> BoundingBoxScoreSummary:
     opencv_target_image = _get_resized_opencv_image(
         target_image,
         image_cache=image_cache,
@@ -215,7 +221,7 @@ def get_bounding_box_match_score(
     LOGGER.debug('bounding_box (for score): %s', bounding_box)
     if bounding_box.width < 10 or bounding_box.height < 10:
         LOGGER.debug('bounding box too small')
-        return 0.0
+        return BoundingBoxScoreSummary(score=0.0, target_bounding_box=target_bounding_box)
     cropped_target_image = crop_image_to_bounding_box(
         opencv_target_image, bounding_box
     )
@@ -230,7 +236,7 @@ def get_bounding_box_match_score(
         resize_image(resized_template_image, similarity_width, similarity_height)
     )
     LOGGER.debug('score: %s', score)
-    return score
+    return BoundingBoxScoreSummary(score=score, target_bounding_box=target_bounding_box)
 
 
 def _get_object_match(  # pylint: disable=too-many-return-statements
@@ -352,7 +358,7 @@ def _get_object_match(  # pylint: disable=too-many-return-statements
     LOGGER.debug('dst_rescaled: %s', dst_rescaled)
     _target_bounding_box = get_bounding_box_for_points(dst_rescaled)
     LOGGER.debug('_target_bounding_box: %s', _target_bounding_box)
-    score = get_bounding_box_match_score(
+    score_summary = get_bounding_box_match_score_summary(
         _target_bounding_box,
         target_image=target_image,
         template_image=template_image,
@@ -360,13 +366,15 @@ def _get_object_match(  # pylint: disable=too-many-return-statements
         target_image_id=target_image_id,
         template_image_id=template_image_id
     )
+    score = score_summary.score
     LOGGER.debug('score: %s', score)
     if score < score_threshold:
         return EMPTY_IMAGE_OBJECT_MATCH_RESULT
     result = ImageObjectMatchResult(
         target_points=dst_rescaled,
         keypoint_match_count=len(good_matches),
-        score=score
+        score=score,
+        target_bounding_box=score_summary.target_bounding_box
     )
     return result
 

--- a/tests/utils/image_object_matching_test.py
+++ b/tests/utils/image_object_matching_test.py
@@ -6,6 +6,8 @@ from sklearn.datasets import load_sample_image
 
 from sciencebeam_gym.utils.bounding_box import BoundingBox
 from sciencebeam_gym.utils.image_object_matching import (
+    get_bounding_box_for_image,
+    get_bounding_box_match_score_summary,
     get_image_list_object_match,
     get_image_array_with_max_resolution,
     get_sift_detector_matcher,
@@ -98,6 +100,24 @@ class TestGetImageArrayWithMaxResolution:
             max_height=0
         )
         assert result_image_array.shape[:2] == (50, 100)
+
+
+class TestGetBoundingBoxMatchScoreSummary:
+    def test_should_evaluate_perfect_match(
+        self,
+        sample_image: PIL.Image
+    ):
+        target_bounding_box = get_bounding_box_for_image(sample_image)
+        score_summary = get_bounding_box_match_score_summary(
+            target_bounding_box,
+            target_image=sample_image,
+            template_image=sample_image,
+            image_cache={},
+            target_image_id='target',
+            template_image_id='template'
+        )
+        assert score_summary.score == 1.0
+        assert score_summary.target_bounding_box == target_bounding_box
 
 
 class TestGetObjectMatch:


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/188

After the bounding box is coming out of the SIFT algorithm,
another step will attempt to improve the bounding box slightly by adjusting the edges and compare the score.
The success of that also depends on the score being meaningful.
Enabling that feature via `--max-bounding-box-adjustment-iterations` will take a bit more time.