### PR TITLE
implemented skip errors for find figure bounding box pipeline

### DIFF
--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
@@ -529,7 +529,9 @@ class FindBoundingBoxItem(NamedTuple):
 
 class FindBoundingBoxPipelineFactory(AbstractPipelineFactory[FindBoundingBoxItem]):
     def __init__(self, args: argparse.Namespace):
-        super().__init__(resume=args.resume)
+        super().__init__(
+            **AbstractPipelineFactory.get_init_kwargs_for_parsed_args(args)
+        )
         self.args = args
         self.output_base_path = args.output_path
         self.pdf_base_path = args.pdf_base_path

--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
@@ -279,7 +279,7 @@ def get_args_parser():
         help='Convert images to grayscale internally'
     )
     parser.add_argument(
-        '--skip-errors',
+        '--ignore-unmatched-graphics',
         action='store_true',
         help='Skip errors finding bounding boxes and output missing annotations'
     )
@@ -390,7 +390,7 @@ def process_single_document(
     max_internal_width: int,
     max_internal_height: int,
     use_grayscale: bool,
-    skip_errors: bool,
+    ignore_unmatched_graphics: bool,
     max_bounding_box_adjustment_iterations: int,
     output_xml_path: Optional[str] = None,
     output_annotated_images_path: Optional[str] = None
@@ -454,7 +454,7 @@ def process_single_document(
         if image_descriptor.related_element_id:
             annotation['related_element_id'] = image_descriptor.related_element_id
         if not image_list_match_result:
-            if not skip_errors:
+            if not ignore_unmatched_graphics:
                 raise GraphicImageNotFoundError(
                     'image bounding box not found for: %r' % image_descriptor.href
                 )
@@ -541,7 +541,7 @@ class FindBoundingBoxPipelineFactory(AbstractPipelineFactory[FindBoundingBoxItem
         self.max_internal_width = args.max_internal_width
         self.max_internal_height = args.max_internal_height
         self.use_grayscale = args.use_grayscale
-        self.skip_errors = args.skip_errors
+        self.ignore_unmatched_graphics = args.ignore_unmatched_graphics
         self.max_bounding_box_adjustment_iterations = args.max_bounding_box_adjustment_iterations
 
     def process_item(self, item: FindBoundingBoxItem):
@@ -564,7 +564,7 @@ class FindBoundingBoxPipelineFactory(AbstractPipelineFactory[FindBoundingBoxItem
             max_internal_width=self.max_internal_width,
             max_internal_height=self.max_internal_height,
             use_grayscale=self.use_grayscale,
-            skip_errors=self.skip_errors,
+            ignore_unmatched_graphics=self.ignore_unmatched_graphics,
             output_xml_path=output_xml_file,
             output_annotated_images_path=output_annotated_images_path,
             max_bounding_box_adjustment_iterations=self.max_bounding_box_adjustment_iterations

--- a/sciencebeam_gym/utils/pipeline.py
+++ b/sciencebeam_gym/utils/pipeline.py
@@ -160,7 +160,7 @@ class AbstractPipelineFactory(Generic[T_Item]):
             LOGGER.debug('configuring pipeline, skipping errors')
             _pipeline |= (
                 "Process Item" >> MapOrLog(
-                    beam.Map(self.process_item),
+                    self.process_item,
                     error_count=MetricCounters.ERROR_COUNT
                 )
                 | "Count" >> Count(MetricCounters.ITEM_COUNT, counter_value_fn=None)

--- a/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
+++ b/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
@@ -539,3 +539,62 @@ class TestMain:
         LOGGER.debug('json_data: %s', json_data)
         missing_annotations_json = json_data['missing_annotations']
         assert [a['file_name'] for a in missing_annotations_json] == [image_path.name]
+
+    def test_should_skip_errors_not_using_beam(
+        self,
+        source_path: Path,
+        output_path: Path,
+        sample_image: PIL.Image.Image
+    ):
+        LOGGER.debug('sample_image: %sx%s', sample_image.width, sample_image.height)
+        image_path = source_path / 'test.jpg'
+        pdf_path = source_path / f'{NAME_1}.pdf'
+        xml_path = source_path / f'{NAME_1}.xml'
+        output_json_path = output_path / f'{NAME_1}{DEFAULT_OUTPUT_JSON_FILE_SUFFIX}'
+        xml_path.write_bytes(etree.tostring(
+            JATS_E.article(JATS_E.body(JATS_E.sec(JATS_E.fig(
+                JATS_E.graphic({XLINK_HREF: image_path.name})
+            ))))
+        ))
+        sample_image.save(image_path, 'JPEG')
+        save_images_as_pdf(pdf_path, [PIL.Image.fromarray(np.zeros((200, 200), dtype=np.uint8))])
+        main([
+            '--pdf-file',
+            str(pdf_path),
+            '--xml-file',
+            str(xml_path),
+            '--output-path',
+            str(output_path),
+            '--skip-errors'
+        ])
+        assert not output_json_path.exists()
+
+    def test_should_skip_errors_using_beam(
+        self,
+        source_path: Path,
+        output_path: Path,
+        sample_image: PIL.Image.Image
+    ):
+        LOGGER.debug('sample_image: %sx%s', sample_image.width, sample_image.height)
+        image_path = source_path / 'test.jpg'
+        pdf_path = source_path / f'{NAME_1}.pdf'
+        xml_path = source_path / f'{NAME_1}.xml'
+        output_json_path = output_path / f'{NAME_1}{DEFAULT_OUTPUT_JSON_FILE_SUFFIX}'
+        xml_path.write_bytes(etree.tostring(
+            JATS_E.article(JATS_E.body(JATS_E.sec(JATS_E.fig(
+                JATS_E.graphic({XLINK_HREF: image_path.name})
+            ))))
+        ))
+        sample_image.save(image_path, 'JPEG')
+        save_images_as_pdf(pdf_path, [PIL.Image.fromarray(np.zeros((200, 200), dtype=np.uint8))])
+        main([
+            '--pdf-file',
+            str(pdf_path),
+            '--xml-file',
+            str(xml_path),
+            '--output-path',
+            str(output_path),
+            '--skip-errors',
+            '--use-beam'
+        ])
+        assert not output_json_path.exists()

--- a/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
+++ b/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
@@ -248,7 +248,8 @@ class TestMain:
             '--xml-file',
             str(xml_path),
             '--output-path',
-            str(output_path)
+            str(output_path),
+            '--use-beam'
         ])
         assert output_json_path.exists()
         json_data = json.loads(output_json_path.read_text())

--- a/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
+++ b/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
@@ -532,7 +532,7 @@ class TestMain:
             str(xml_path),
             '--output-path',
             str(output_path),
-            '--skip-errors'
+            '--ignore-unmatched-graphics'
         ])
         assert output_json_path.exists()
         json_data = json.loads(output_json_path.read_text())


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/195

This enables to skip documents that failed to match all of the graphics (as opposed to ignoring graphics that couldn't be matched).