### PR TITLE
improve memory consumption with large images when finding bounding boxes

### DIFF
--- a/sciencebeam_gym/utils/cv.py
+++ b/sciencebeam_gym/utils/cv.py
@@ -58,6 +58,12 @@ def get_image_array_with_max_resolution(
     )
 
 
+def load_pil_image_from_file(image_path: str) -> PIL.Image.Image:
+    return get_pil_image_for__opencv_image(
+        cv.imread(image_path)
+    )
+
+
 def crop_image_to_bounding_box(
     src: np.ndarray,
     bounding_box: BoundingBox,

--- a/sciencebeam_gym/utils/cv.py
+++ b/sciencebeam_gym/utils/cv.py
@@ -28,6 +28,36 @@ def resize_image(src: np.ndarray, width: int, height: int) -> np.ndarray:
     )
 
 
+def get_image_array_with_max_resolution(
+    image_array: np.ndarray,
+    max_width: int,
+    max_height: int
+) -> np.ndarray:
+    original_height, original_width = image_array.shape[:2]
+    if (
+        (not max_width or original_width <= max_width)
+        and (not max_height or original_height <= max_height)
+    ):
+        LOGGER.debug(
+            'image within expected dimension: %sx%s <= %sx%s',
+            original_width, original_height, max_width, max_height
+        )
+        return image_array
+    target_width_based_on_height = int(
+        original_width * max_height / original_height
+    )
+    target_height_based_on_width = int(
+        original_height * max_width / original_width
+    )
+    if max_height and (not max_width or target_width_based_on_height <= max_width):
+        return resize_image(
+            image_array, width=target_width_based_on_height, height=max_height
+        )
+    return resize_image(
+        image_array, width=max_width, height=target_height_based_on_width
+    )
+
+
 def crop_image_to_bounding_box(
     src: np.ndarray,
     bounding_box: BoundingBox,

--- a/sciencebeam_gym/utils/image_object_matching.py
+++ b/sciencebeam_gym/utils/image_object_matching.py
@@ -9,6 +9,7 @@ import skimage.metrics
 from sciencebeam_gym.utils.bounding_box import EMPTY_BOUNDING_BOX, BoundingBox
 from sciencebeam_gym.utils.cv import (
     crop_image_to_bounding_box,
+    get_image_array_with_max_resolution,
     resize_image,
     to_opencv_image
 )
@@ -98,36 +99,6 @@ DEFAULT_MAX_WIDTH = 0
 DEFAULT_MAX_HEIGHT = DEFAULT_MAX_WIDTH
 
 DEFAULT_MAX_BOUNDING_BOX_ADJUSTMENT_ITERATIONS = 0
-
-
-def get_image_array_with_max_resolution(
-    image_array: np.ndarray,
-    max_width: int = DEFAULT_MAX_WIDTH,
-    max_height: int = DEFAULT_MAX_HEIGHT
-) -> np.ndarray:
-    original_height, original_width = image_array.shape[:2]
-    if (
-        (not max_width or original_width <= max_width)
-        and (not max_height or original_height <= max_height)
-    ):
-        LOGGER.debug(
-            'image within expected dimension: %sx%s <= %sx%s',
-            original_width, original_height, max_width, max_height
-        )
-        return image_array
-    target_width_based_on_height = int(
-        original_width * max_height / original_height
-    )
-    target_height_based_on_width = int(
-        original_height * max_width / original_width
-    )
-    if max_height and (not max_width or target_width_based_on_height <= max_width):
-        return resize_image(
-            image_array, width=target_width_based_on_height, height=max_height
-        )
-    return resize_image(
-        image_array, width=max_width, height=target_height_based_on_width
-    )
 
 
 def _get_resized_opencv_image(

--- a/sciencebeam_gym/utils/io.py
+++ b/sciencebeam_gym/utils/io.py
@@ -1,4 +1,5 @@
 import logging
+from shutil import copyfileobj
 from typing import Optional
 
 import fsspec
@@ -36,3 +37,9 @@ def write_bytes(path_or_url: str, data: bytes, **kwargs):
 def write_text(path_or_url: str, data: str, **kwargs):
     with open_file(path_or_url, mode='wt', **kwargs) as fp:
         return fp.write(data)
+
+
+def copy_file(source_path_or_url: str, target_path_or_url, **kwargs):
+    with open_file(source_path_or_url, mode='rb', **kwargs) as source_fp:
+        with open_file(target_path_or_url, mode='wb', **kwargs) as target_fp:
+            copyfileobj(source_fp, target_fp)

--- a/sciencebeam_gym/utils/pipeline.py
+++ b/sciencebeam_gym/utils/pipeline.py
@@ -180,6 +180,8 @@ class AbstractPipelineFactory(Generic[T_Item]):
         item_list: List[T_Item],
         save_main_session: bool = False
     ):
+        if args.num_workers == 0:
+            args.num_workers = None
         pipeline_options = PipelineOptions.from_dictionary({
             key: value
             for key, value in vars(args).items()

--- a/tests/utils/cv_test.py
+++ b/tests/utils/cv_test.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from sciencebeam_gym.utils.cv import (
+    get_image_array_with_max_resolution
+)
+
+
+class TestGetImageArrayWithMaxResolution:
+    def test_should_keep_original_image_without_max_width(self):
+        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=0,
+            max_height=200
+        )
+        assert result_image_array.shape == original_image_array.shape
+
+    def test_should_keep_original_image_without_max_height(self):
+        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=200,
+            max_height=0
+        )
+        assert result_image_array.shape == original_image_array.shape
+
+    def test_should_keep_original_image_if_within_max_dimensions(self):
+        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=200,
+            max_height=200
+        )
+        assert result_image_array.shape == original_image_array.shape
+
+    def test_should_resize_to_max_height(self):
+        original_image_array = np.zeros((200, 100, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=100,
+            max_height=100
+        )
+        assert result_image_array.shape[:2] == (100, 50)
+
+    def test_should_resize_to_max_width(self):
+        original_image_array = np.zeros((100, 200, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=100,
+            max_height=100
+        )
+        assert result_image_array.shape[:2] == (50, 100)
+
+    def test_should_resize_to_max_height_without_max_width(self):
+        original_image_array = np.zeros((200, 100, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=0,
+            max_height=100
+        )
+        assert result_image_array.shape[:2] == (100, 50)
+
+    def test_should_resize_to_max_width_without_max_height(self):
+        original_image_array = np.zeros((100, 200, 3), dtype=np.uint8)
+        result_image_array = get_image_array_with_max_resolution(
+            original_image_array,
+            max_width=100,
+            max_height=0
+        )
+        assert result_image_array.shape[:2] == (50, 100)

--- a/tests/utils/image_object_matching_test.py
+++ b/tests/utils/image_object_matching_test.py
@@ -10,7 +10,6 @@ from sciencebeam_gym.utils.image_object_matching import (
     get_bounding_box_for_image,
     get_bounding_box_match_score_summary,
     get_image_list_object_match,
-    get_image_array_with_max_resolution,
     get_sift_detector_matcher,
     get_orb_detector_matcher,
     get_object_match
@@ -39,71 +38,6 @@ def _white_image() -> PIL.Image.Image:
     return PIL.Image.fromarray(
         np.full((400, 600, 3), 255, dtype=np.uint8)
     )
-
-
-class TestGetImageArrayWithMaxResolution:
-    def test_should_keep_original_image_without_max_width(self):
-        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=0,
-            max_height=200
-        )
-        assert result_image_array.shape == original_image_array.shape
-
-    def test_should_keep_original_image_without_max_height(self):
-        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=200,
-            max_height=0
-        )
-        assert result_image_array.shape == original_image_array.shape
-
-    def test_should_keep_original_image_if_within_max_dimensions(self):
-        original_image_array = np.zeros((120, 100, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=200,
-            max_height=200
-        )
-        assert result_image_array.shape == original_image_array.shape
-
-    def test_should_resize_to_max_height(self):
-        original_image_array = np.zeros((200, 100, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=100,
-            max_height=100
-        )
-        assert result_image_array.shape[:2] == (100, 50)
-
-    def test_should_resize_to_max_width(self):
-        original_image_array = np.zeros((100, 200, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=100,
-            max_height=100
-        )
-        assert result_image_array.shape[:2] == (50, 100)
-
-    def test_should_resize_to_max_height_without_max_width(self):
-        original_image_array = np.zeros((200, 100, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=0,
-            max_height=100
-        )
-        assert result_image_array.shape[:2] == (100, 50)
-
-    def test_should_resize_to_max_width_without_max_height(self):
-        original_image_array = np.zeros((100, 200, 3), dtype=np.uint8)
-        result_image_array = get_image_array_with_max_resolution(
-            original_image_array,
-            max_width=100,
-            max_height=0
-        )
-        assert result_image_array.shape[:2] == (50, 100)
 
 
 class TestGetBoundingBoxMatchScoreSummary:


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/196

There is now a `--pdf-scale-to` argument to scale PDF images.
There are also other small improvements to reduce the memory consumption or logging progress.