### PR TITLE
fixed xml when finding bounding boxes

### DIFF
--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
@@ -441,6 +441,13 @@ def get_cache(temp_dir: str, memory_cache_size: int):
     ])
 
 
+def parse_and_fix_xml(xml_path: str) -> etree.ElementBase:
+    LOGGER.info('parsing XML file(%r)', os.path.basename(xml_path))
+    xml_data = read_bytes(xml_path)
+    xml_data = xml_data.replace(b'&dagger;', b'&#x2020;')
+    return etree.fromstring(xml_data)
+
+
 def process_single_document(
     pdf_path: str,
     image_paths: Optional[List[str]],
@@ -461,8 +468,7 @@ def process_single_document(
     pdf_images = get_images_from_pdf(pdf_path, pdf_scale_to=pdf_scale_to)
     xml_root: Optional[etree.ElementBase] = None
     if xml_path:
-        LOGGER.info('parsing XML file(%r)', os.path.basename(xml_path))
-        xml_root = etree.fromstring(read_bytes(xml_path))
+        xml_root = parse_and_fix_xml(xml_path)
         image_descriptors = get_graphic_element_descriptors_from_xml_node(
             xml_root,
             parent_dirname=os.path.dirname(xml_path)

--- a/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
+++ b/sciencebeam_gym/tools/image_annotation/find_bounding_boxes_utils.py
@@ -444,6 +444,7 @@ def get_cache(temp_dir: str, memory_cache_size: int):
 def parse_and_fix_xml(xml_path: str) -> etree.ElementBase:
     LOGGER.info('parsing XML file(%r)', os.path.basename(xml_path))
     xml_data = read_bytes(xml_path)
+    xml_data = xml_data.lstrip()
     xml_data = xml_data.replace(b'&dagger;', b'&#x2020;')
     return etree.fromstring(xml_data)
 

--- a/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
+++ b/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
@@ -31,6 +31,7 @@ from sciencebeam_gym.tools.image_annotation.find_bounding_boxes_utils import (
     GraphicImageNotFoundError,
     format_coords_attribute_value,
     main,
+    parse_and_fix_xml,
     parse_args,
     save_annotated_images
 )
@@ -102,6 +103,22 @@ def save_images_as_pdf(path_or_io: Union[str, Path, IO], images: List[PIL.Image.
         save_all=True,
         append_images=images[1:]
     )
+
+
+class TestParseAndFixXml:
+    def test_should_parse_valid_xml(self, tmp_path: Path):
+        xml_file = tmp_path / 'test.xml'
+        xml_file.write_text('<xml>text</xml>')
+        xml_root = parse_and_fix_xml(str(xml_file))
+        assert xml_root.tag == 'xml'
+        assert xml_root.text == 'text'
+
+    def test_should_parse_xml_with_missing_dagger_entity(self, tmp_path: Path):
+        xml_file = tmp_path / 'test.xml'
+        xml_file.write_text('<xml>text&dagger;</xml>')
+        xml_root = parse_and_fix_xml(str(xml_file))
+        assert xml_root.tag == 'xml'
+        assert xml_root.text == 'text\u2020'
 
 
 class TestSaveAnnotatedImages:

--- a/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
+++ b/tests/tools/image_annotation/find_bounding_boxes_utils_test.py
@@ -108,17 +108,24 @@ def save_images_as_pdf(path_or_io: Union[str, Path, IO], images: List[PIL.Image.
 class TestParseAndFixXml:
     def test_should_parse_valid_xml(self, tmp_path: Path):
         xml_file = tmp_path / 'test.xml'
-        xml_file.write_text('<xml>text</xml>')
+        xml_file.write_text('<?xml version="1.0" encoding="UTF-8"?><xml>text</xml>')
         xml_root = parse_and_fix_xml(str(xml_file))
         assert xml_root.tag == 'xml'
         assert xml_root.text == 'text'
 
     def test_should_parse_xml_with_missing_dagger_entity(self, tmp_path: Path):
         xml_file = tmp_path / 'test.xml'
-        xml_file.write_text('<xml>text&dagger;</xml>')
+        xml_file.write_text('<?xml version="1.0" encoding="UTF-8"?><xml>text&dagger;</xml>')
         xml_root = parse_and_fix_xml(str(xml_file))
         assert xml_root.tag == 'xml'
         assert xml_root.text == 'text\u2020'
+
+    def test_should_parse_xml_with_extra_spaces_in_the_beginning(self, tmp_path: Path):
+        xml_file = tmp_path / 'test.xml'
+        xml_file.write_text(' \n <?xml version="1.0" encoding="UTF-8"?>\n<xml>text</xml>')
+        xml_root = parse_and_fix_xml(str(xml_file))
+        assert xml_root.tag == 'xml'
+        assert xml_root.text == 'text'
 
 
 class TestSaveAnnotatedImages:


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/196

Some XML files have minor invalid markup.
This applies a fix / workaround.

As has previously done in: https://github.com/elifesciences/sciencebeam-trainer-grobid-tools/pull/135